### PR TITLE
fix: Ensure text is truly flat by setting depth to zero

### DIFF
--- a/main.js
+++ b/main.js
@@ -96,9 +96,9 @@ fontLoader.load(
             {
                 font: font,
                 size: 5,
-                depth: 0.01, // Make text virtually flat
-                curveSegments: 12, // curveSegments can remain for smoothness of character curves
-                bevelEnabled: false, // Ensure bevel is off
+                depth: 0, // Set text depth to 0 for true flatness
+                curveSegments: 12,
+                bevelEnabled: false,
             }
         );
 


### PR DESCRIPTION
This commit updates the Three.js static site to ensure the displayed text "Cory Richard" is rendered as a flat object.

Changes:
- Modified `TextGeometry` parameters in `main.js`:
    - `depth` explicitly set to `0`. This removes all extrusion, making the text geometrically flat.
- `bevelEnabled` remains `false`.

This addresses your feedback regarding perceived depth in the text. The camera positioning and resize handling remain unchanged and are expected to work correctly with the flat text.