### PR TITLE
fix: Update GLB model URL

### DIFF
--- a/main.js
+++ b/main.js
@@ -99,7 +99,7 @@ function adjustCameraForModel() {
 
 // GLTF Loader
 const gltfLoader = new GLTFLoader();
-const modelUrl = 'https://raw.githubusercontent.com/RSOS-ops/jules-test/main/HoodedCory_PlanarFace_BigWireframe_pck.glb';
+const modelUrl = 'https://raw.githubusercontent.com/RSOS-ops/jules-test/main/HoodedCory_PlanarFace_BigWireframe.glb';
 
 gltfLoader.load(
     modelUrl,


### PR DESCRIPTION
This commit updates the URL for the GLB model to be loaded into the scene. The new URL is: https://raw.githubusercontent.com/RSOS-ops/jules-test/main/HoodedCory_PlanarFace_BigWireframe.glb

All other loading, lighting, and camera adjustment logic remains unchanged.