### PR TITLE
feat: Add OrbitControls for interactive camera

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'; // Added this line
 
 // Scene
 const scene = new THREE.Scene();
@@ -12,6 +13,15 @@ const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerH
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
+
+// Controls
+let controls; // Declare controls variable
+controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 0, 0); // Orbit around the center of the scene (where the model is)
+controls.enableDamping = true;   // Enable damping (inertia)
+controls.dampingFactor = 0.05;   // Damping factor
+// controls.autoRotate = false; // Default is false, so not strictly needed
+// controls.screenSpacePanning = false; // Default is true, keep it for now
 
 // Lighting
 const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
@@ -126,6 +136,12 @@ gltfLoader.load(
 // Render loop
 function animate() {
     requestAnimationFrame(animate);
+
+    // Required if controls.enableDamping or controls.autoRotate are set to true
+    if (controls.enableDamping) {
+        controls.update();
+    }
+
     renderer.render(scene, camera);
 }
 animate();


### PR DESCRIPTION
Integrates OrbitControls into the Three.js scene to allow you to interactively rotate, pan, and zoom the camera around the model.

Key changes:
- Imported `OrbitControls` from three.js addons.
- Instantiated `OrbitControls` with the main camera and renderer's DOM element.
- Configured controls:
    - Target set to (0,0,0) (model center).
    - Damping enabled (`enableDamping = true`, `dampingFactor = 0.05`) for smoother interaction.
- Updated the `animate` render loop to call `controls.update()` each frame, which is necessary for damping to take effect.
- Verified that the existing `adjustCameraForModel` function, which sets the initial camera position and handles resize events, works correctly with OrbitControls. The controls will respect the camera position set by this function and then allow user interaction from that state.