### PR TITLE
feat: Add model-parented directional light

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,10 +8,6 @@ scene.background = new THREE.Color(0x000000);
 
 // Camera
 const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-// Add headlight as a child of the camera
-camera.add(headlight);
-// Position the headlight slightly in front of the camera (local space of camera)
-headlight.position.set(0, 0, 1);
 
 // Renderer
 const renderer = new THREE.WebGLRenderer({ antialias: true });
@@ -34,16 +30,8 @@ const directionalLight = new THREE.DirectionalLight(0xffffff, 2.5);
 directionalLight.position.set(10, 10, 10);
 scene.add(directionalLight);
 
-// Second Directional Light (Headlight)
-const headlight = new THREE.DirectionalLight(0xffffff, 0.8); // White, moderate intensity
-// headlight.target will default to (0,0,0) world, which is correct for the model.
-
-// ... further modifications will happen in the next step (parenting to camera)
-// For now, just declare it. We will add it to the camera in the next step.
-// scene.add(headlight); // Will be added to camera, not directly to scene.
-// The camera itself (with the light as a child) needs to be added to the scene if not already.
-// However, the camera is used by renderer.render(scene, camera) - it doesn't need to be in the scene graph itself.
-// The headlight, being a child of the camera, will illuminate the scene based on the camera's transform.
+// New Object-Parented Directional Light - instantiated here, configured with model later
+const objectDirectionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
 
 // Model
 let model; // To store the loaded model
@@ -138,6 +126,20 @@ gltfLoader.load(
         model.position.sub(center);
 
         console.log('Model added to scene and centered.');
+
+        // Create and add target for objectDirectionalLight
+        const lightTarget = new THREE.Object3D();
+        model.add(lightTarget); // Add target to the model, it will be at model's local origin (0,0,0)
+        objectDirectionalLight.target = lightTarget;
+
+        // Add the light to the model
+        model.add(objectDirectionalLight);
+        // Position it in front of the model (local Z axis)
+        // The distance (e.g., 5) might need adjustment based on typical model scale.
+        objectDirectionalLight.position.set(0, 0, 5);
+
+        console.log("ObjectDirectionalLight added to model and positioned.");
+
         adjustCameraForModel(); // Adjust camera AFTER model is loaded and centered
     },
     (xhr) => {


### PR DESCRIPTION
Adds a new directional light that is parented to the loaded GLTF model. This light moves and rotates with the model, consistently illuminating its front (local +Z) side.

Key changes:
- Removed any previous camera-parented 'headlight' code.
- Instantiated a new `DirectionalLight` (`objectDirectionalLight`) with an intensity of 0.8.
- Created an `Object3D` (`lightTarget`) and added it as a child of the loaded model (at its local origin).
- Set `objectDirectionalLight.target` to this `lightTarget`.
- Added `objectDirectionalLight` as a child of the model.
- Positioned `objectDirectionalLight` at (0,0,5) in the model's local coordinate system, making it shine from the model's local +Z direction towards its own origin.

This light supplements the existing ambient and world-fixed directional lights, providing consistent frontal illumination for the model itself, regardless of its orientation in the world or the camera's orbit.