### PR TITLE
Refactor: Remove parented directional light and adjust scene lighting

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,14 +24,13 @@ controls.dampingFactor = 0.05;   // Damping factor
 // controls.screenSpacePanning = false; // Default is true, keep it for now
 
 // Lighting
-const ambientLight = new THREE.AmbientLight(0xffffff, 0);
+const ambientLight = new THREE.AmbientLight(0xffffff, 1);
 scene.add(ambientLight);
-const directionalLight = new THREE.DirectionalLight(0xffffff, 0);
+const directionalLight = new THREE.DirectionalLight(0xffffff, 25);
 directionalLight.position.set(10, 10, 10);
 scene.add(directionalLight);
 
 // New Directional Light for the model
-const objectModelLight = new THREE.DirectionalLight(0xffffff, 25);
 
 // Model
 let model; // To store the loaded model
@@ -126,22 +125,6 @@ gltfLoader.load(
         model.position.sub(center); // Center the model at world origin
 
         console.log('Model added to scene and centered.');
-
-        // Configure objectModelLight
-        // a. Create and Add Target
-        const modelLightTarget = new THREE.Object3D();
-        model.add(modelLightTarget); // Target is at model's local origin (0,0,0)
-
-        // b. Assign Target to Light
-        objectModelLight.target = modelLightTarget;
-
-        // c. Add Light to Model
-        model.add(objectModelLight);
-
-        // d. Set Light's Local Position (e.g., 5 units in front along model's local +Z axis)
-        objectModelLight.position.set(0, 0, 4);
-
-        console.log("ObjectModelLight configured, parented to model, and positioned.");
 
         adjustCameraForModel();
     },


### PR DESCRIPTION
This commit removes the `objectModelLight` which was parented to the GLTF model. Its definition and all associated configuration logic within the GLTF loader callback have been deleted from `main.js`.

To ensure the scene remains properly illuminated, the intensity of the standard `directionalLight` has been increased from 0 to 25. Additionally, the intensity of the `ambientLight` has been increased from 0 to 1 to provide a general base illumination.

The scene now contains only one ambient light and one main directional light as per the requirements.