### PR TITLE
feat: Add parented spotlight to GLTF model

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,6 +30,14 @@ const directionalLight = new THREE.DirectionalLight(0xffffff, 25);
 directionalLight.position.set(10, 10, 10);
 scene.add(directionalLight);
 
+// Spotlight for the model
+const spotLight = new THREE.SpotLight(0xffffff, 100); // Intensity updated
+spotLight.distance = 5; // Distance updated
+spotLight.angle = Math.PI / 8; // Angle updated
+spotLight.penumbra = 0.5; // Penumbra updated
+spotLight.decay = 2; // Standard decay
+// scene.add(spotLight); // Will be added as a child of the model later
+
 // New Directional Light for the model
 
 // Model
@@ -125,6 +133,22 @@ gltfLoader.load(
         model.position.sub(center); // Center the model at world origin
 
         console.log('Model added to scene and centered.');
+
+        // Configure SpotLight
+        const spotLightTarget = new THREE.Object3D();
+        model.add(spotLightTarget); // Target is at model's local origin (0,0,0)
+        spotLightTarget.position.set(0, 0, 0); // Explicitly set target position if needed
+
+        spotLight.target = spotLightTarget;
+        model.add(spotLight);
+        spotLight.position.set(0, 0.5, 1.5); // Position updated
+
+        console.log("SpotLight configured, parented to model, and positioned.");
+
+        // Add Spotlight Helper for debugging
+        const spotLightHelper = new THREE.SpotLightHelper(spotLight);
+        scene.add(spotLightHelper);
+        console.log("SpotLightHelper added to the scene.");
 
         adjustCameraForModel();
     },


### PR DESCRIPTION
This commit introduces a `THREE.SpotLight` that is parented to the loaded GLTF model. The spotlight is configured to be positioned in front of the model and aim at its center.

Key changes:
- Defined a new `THREE.SpotLight` in `main.js` with configurable parameters (intensity, angle, distance, penumbra).
- Added logic within the `gltfLoader.load` callback to:
    - Create a target object for the spotlight and parent it to the model.
    - Parent the spotlight itself to the model.
    - Set the spotlight's local position and target.
- Initial parameters for the spotlight's angle, distance, intensity, and position have been set to illuminate roughly 1/5th of the object, though these may require visual fine-tuning.
- Added a `THREE.SpotLightHelper` to the scene for easier debugging and visualization of the spotlight's properties.

The spotlight's position and illumination characteristics are now tied to the model's own transform, ensuring consistent lighting relative to the object during your interaction (e.g., orbit controls).