### PR TITLE
Refactor: Clarify directional light behavior and add helper

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,6 +30,17 @@ const directionalLight = new THREE.DirectionalLight(0xffffff, 25);
 directionalLight.position.set(10, 10, 10);
 scene.add(directionalLight);
 
+// Explicitly set the target for the directional light
+const directionalLightTarget = new THREE.Object3D();
+directionalLightTarget.position.set(0, 0, 0); // Target the world origin
+scene.add(directionalLightTarget); // Add target to the scene
+directionalLight.target = directionalLightTarget;
+
+// Add DirectionalLightHelper for debugging
+const directionalLightHelper = new THREE.DirectionalLightHelper(directionalLight, 5); // Second arg is helper size
+scene.add(directionalLightHelper);
+console.log("DirectionalLightHelper added to the scene.");
+
 // Spotlight for the model
 const spotLight = new THREE.SpotLight(0xffffff, 100); // Intensity updated
 spotLight.distance = 5; // Distance updated


### PR DESCRIPTION
This commit addresses concerns about the main directional light appearing to move with the GLTF object.

My investigations confirmed that the `directionalLight` was already correctly positioned statically in world space `(10,10,10)` and added directly to the scene, targeting the world origin `(0,0,0)`. The perception of movement was likely due to the changing orientation of the model relative to the fixed light source during camera orbiting.

To improve clarity and aid debugging:
- The `directionalLight.target` is now explicitly set to a `THREE.Object3D` positioned at the world origin. While this doesn't change the default behavior, it makes the target explicit.
- A `THREE.DirectionalLightHelper` has been added to the scene. This helper visually represents the light's position and direction, making its static nature evident.

No other modifications to the `directionalLight`'s positioning logic were necessary as it was already correctly implemented.