### PR TITLE
Refactor: Adjust lighting for spotlight focus

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,9 +24,9 @@ controls.dampingFactor = 0.05;   // Damping factor
 // controls.screenSpacePanning = false; // Default is true, keep it for now
 
 // Lighting
-const ambientLight = new THREE.AmbientLight(0xffffff, 1);
+const ambientLight = new THREE.AmbientLight(0xffffff, 0);
 scene.add(ambientLight);
-const directionalLight = new THREE.DirectionalLight(0xffffff, 25);
+const directionalLight = new THREE.DirectionalLight(0xffffff, 0);
 directionalLight.position.set(10, 10, 10);
 scene.add(directionalLight);
 
@@ -42,10 +42,10 @@ scene.add(directionalLightHelper);
 console.log("DirectionalLightHelper added to the scene.");
 
 // Spotlight for the model
-const spotLight = new THREE.SpotLight(0xffffff, 100); // Intensity updated
-spotLight.distance = 5; // Distance updated
-spotLight.angle = Math.PI / 8; // Angle updated
-spotLight.penumbra = 0.5; // Penumbra updated
+const spotLight = new THREE.SpotLight(0xffffff, 100); // Intensity 100
+spotLight.distance = 1; // Distance updated
+spotLight.angle = Math.PI / 4; // Angle updated
+spotLight.penumbra = 0.5; // Penumbra 0.5
 spotLight.decay = 2; // Standard decay
 // scene.add(spotLight); // Will be added as a child of the model later
 
@@ -152,7 +152,7 @@ gltfLoader.load(
 
         spotLight.target = spotLightTarget;
         model.add(spotLight);
-        spotLight.position.set(0, 0.5, 1.5); // Position updated
+        spotLight.position.set(0, 0.05, 0.1); // Position updated
 
         console.log("SpotLight configured, parented to model, and positioned.");
 


### PR DESCRIPTION
This commit implements the following lighting changes:
- Sets the intensity of the main `directionalLight` to 0.
- Sets the intensity of the `ambientLight` to 0.
- Moves the model-parented `spotLight` to be extremely close to the model's surface (position `(0, 0.05, 0.1)` relative to the model).
- Adjusts the `spotLight` parameters for this new proximity:
    - `distance` (max range) changed to 1.
    - `angle` changed to `Math.PI / 4` (45 degrees) to provide a reasonable illumination area at close range.
    - `intensity` remains at 100 (may need visual tuning).

The scene will now be primarily lit by this closely positioned spotlight, creating a focused illumination effect on the model.