### PR TITLE
Update GLTF model link to local path

### DIFF
--- a/main.js
+++ b/main.js
@@ -123,7 +123,7 @@ function adjustCameraForModel() {
 // Initialize GLTF Loader for loading .glb or .gltf models.
 const gltfLoader = new GLTFLoader();
 // URL of the 3D model to be loaded.
-const modelUrl = 'https://raw.githubusercontent.com/RSOS-ops/jules-test/main/CoryHead_Planar.glb';
+const modelUrl = './CoryHead_Planar.glb';
 
 // Load the GLTF model.
 gltfLoader.load(


### PR DESCRIPTION
I changed the hardcoded GitHub URL for the CoryHead_Planar.glb model in main.js to a local relative path ('./CoryHead_Planar.glb'). This makes your project self-contained and avoids external dependencies for this asset.